### PR TITLE
🔧 Rename "React" to "React.js" for consistency

### DIFF
--- a/src/data/svgs.ts
+++ b/src/data/svgs.ts
@@ -164,7 +164,7 @@ export const svgs: iSVG[] = [
     url: 'https://preactjs.com/'
   },
   {
-    title: 'React',
+    title: 'React.js',
     category: 'Library',
     route: {
       light: '/library/react_light.svg',


### PR DESCRIPTION
- Updated references to "React" by renaming it to "React.js" to maintain naming consistency.
- Ensures clarity and aligns with official naming conventions.
